### PR TITLE
Patch broken drag box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /target
 /*-init.clj
 /resources/public/js/compiled
+/doo-index.html
+/package-lock.json
+/node_modules/
 out
 .idea
 *.iml

--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,1 +1,4 @@
-{:main re-dnd-demo.core}
+^{:open-url "http://[[server-hostname]]:[[server-port]]/demo.html"}
+{:main re-dnd-demo.core
+ :output-to       "resources/public/js/compiled/app-demo.js"
+ :output-dir      "resources/public/js/compiled/demo/out"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-dnd "0.1.8"
+(defproject re-dnd "0.1.9-SNAPSHOT"
   :description "A configurable drag/drop widget + API for re-frame apps"
   :url "https://github.com/Kah0ona/re-dnd.git"
   :license {:name "MIT"}
@@ -37,10 +37,9 @@
                    [binaryage/devtools "0.9.7"]
                    [com.bhauman/rebel-readline-cljs "0.1.4"]
                    [com.bhauman/figwheel-main "0.2.1-SNAPSHOT"]
-                   [org.clojure/tools.nrepl "0.2.13"]
-                   ]
+                   [org.clojure/tools.nrepl "0.2.13"]]
 
-    :plugins [[lein-doo "0.1.8"]
+    :plugins [[lein-doo "0.1.11"]
               [lein-pdo "0.1.1"]]}}
 
   :cljsbuild

--- a/resources/public/css/demo.css
+++ b/resources/public/css/demo.css
@@ -1,6 +1,7 @@
 body {
    font-family: Verdana, sans-serif;
 }
+
 .draggable {
    border: 1px solid red;
    width: 250px;
@@ -48,14 +49,11 @@ body {
    background-color: orange;
 }
 
-
-
 .container {
    width: 800px;
    margin: 0 auto;
    border: 1px solid #ededed;
 }
-
 
 .box {
    width: 100%;
@@ -64,7 +62,6 @@ body {
    padding-top: 30px;
    color: white;
 }
-
 
 .clear {
   clear: both;
@@ -81,7 +78,6 @@ body {
 .draggable {
    margin-bottom: 10px;
 }
-
 
 .btn {
    margin: 20px;


### PR DESCRIPTION
Release 0.1.8 broke the drag-box in the demo. The PR restores the drag-box, making it properly follow the mouse and disappear on drop.