### PR TITLE
fix: update re-frame-utils version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-dnd "0.1.13"
+(defproject re-dnd "0.1.14"
 
   :description "A configurable drag/drop widget + API for re-frame apps"
   :url "https://github.com/Kah0ona/re-dnd.git"
@@ -8,7 +8,7 @@
                  [reagent "0.8.1"]
                  [re-frame "0.10.6"]
                  [com.taoensso/timbre "4.10.0"]
-                 [re-frame-utils "0.1.0"]
+                 [me.flowthing/re-frame-utils "0.1.1"]
                  [fipp "0.6.10"]]
 
 


### PR DESCRIPTION
Updates the re-frame-utils version to a jar that does not contain the
build artifacts.

Errors like below were being thrown at app-startup
```
[INFO] filename violation for ns reagent.impl.component, got: out/reagent/impl/component.cljs expected: reagent/impl/component.cljs (or .cljc)
```

Relevant PR and issue: https://github.com/den1k/re-frame-utils/pull/8 and https://github.com/den1k/re-frame-utils/issues/5